### PR TITLE
Include MLL estimation

### DIFF
--- a/compute_variograms.m
+++ b/compute_variograms.m
@@ -3,6 +3,7 @@
 % Last updated 10/2/2019 to incorporate new analysis
 % Updated 12/19/2019 to modularize calculations
 % Updated 3/17/2020 to better organize permutations of semivariogram fitting
+% Updated 4/20/2022 to include MLL based estimation (fitMethod = 7)
 
 clear; close all; clc;
 
@@ -31,7 +32,7 @@ options.syntheticRange = 30;
 options.funcForm = 1;
 
 % which fitting techniques to use
-options.fitMethod = 1:6;
+options.fitMethod = 1:7;
 
 % labels for lines
 options.linespec{1} = '--k';
@@ -40,7 +41,7 @@ options.linespec{3} = '-c';
 options.linespec{4} = '-g';
 options.linespec{5} = '-b';
 options.linespec{6} = '-k';
-
+options.linespec{7} = '--b';
 
 
 %% load residuals data

--- a/fit_MLL.m
+++ b/fit_MLL.m
@@ -1,0 +1,90 @@
+function [sill, range, loss, methodName, methodNameShort] = fit_MLL(lats, longs, values, options)
+
+% fit variogram sill and range using the log-likelihood of a multivariate 
+% normal distribution as in GP regression.
+% Created by Lukas Bodenmann 04/13/2022
+% This method finds the variance and the lengthscale of the covariance 
+% function that maximize the log-likelihood of the observations.
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Input Variables
+%   lats = list of site lats
+%   longs = list of site longs
+%   values = list of the random variable values at each site
+%   options.fixedSill   = 1 to pre-assume a sill of 1, 
+%                       = 0 to fit sill from data
+%   options.funcForm = 1 for sill*(1-exp(-3 * h / range)); 
+%                    = 2 for sill*(1-exp(-h^0.55 / range))
+%
+% Output Variables
+%   sill = fitted sill for an exponential variogram model
+%   range = fitted range for an exponential variogram model
+%   loss = Average log-likelihood of the fitted model
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+
+% Assemble the input matrix
+X = [lats longs];
+
+% Treat records from stations that were closer than 5m as duplicates and 
+% delete them
+% This affects less than 10 station pairs over all events with more than 
+% 40 recordigs.
+c = 1;
+idx_dupl = int16.empty();
+dist = pos2distv(X, X);
+for i =1:length(dist)
+    p = sum(dist(i,:)<0.005);
+    if p > 1
+        idx_dupl(c) = i;
+        c = c+1;
+    end
+end
+lats(idx_dupl) = []; longs(idx_dupl) = [];
+values(idx_dupl) = [];
+X = [lats longs];
+
+% Specify the covariance functions depending on the variogram forms
+if options.funcForm == 1 && options.fixedSill == 1
+    kfcn = @(XN, XM, theta) exp(-3 * pos2distv(XN,XM)/exp(theta(1)));
+    theta0 = log([45]); % set initial value in log scale
+    gprMdl = fitgp(X, values, kfcn, theta0);
+    range = exp(gprMdl.KernelInformation.KernelParameters); % output
+    sill = 1.0;
+elseif options.funcForm == 2 && options.fixedSill == 1
+    kfcn = @(XN, XM, theta) exp(-1 * pos2distv(XN,XM).^0.55 / exp(theta(1)));
+    theta0 = log([45]);
+    gprMdl = fitgp(X, values, kfcn, theta0);
+    range = exp(gprMdl.KernelInformation.KernelParameters);
+    sill = 1.0;
+elseif options.funcForm == 1 && options.fixedSill == 0
+    kfcn = @(XN, XM, theta) exp(theta(2)) * exp(-3 * pos2distv(XN,XM)/exp(theta(1)));
+    theta0 = log([45, 1.0]);
+    gprMdl = fitgp(X, values, kfcn, theta0);
+    params = exp(gprMdl.KernelInformation.KernelParameters);
+    range = params(1,1);
+    sill = params(2,1);
+elseif options.funcForm == 2 && options.fixedSill == 0
+    kfcn = @(XN, XM, theta) exp(theta(2)) * exp(-1 * pos2distv(XN,XM).^0.55 / exp(theta(1)));
+    theta0 = log([45, 1.0]);
+    gprMdl = fitgp(X, values, kfcn, theta0);
+    params = exp(gprMdl.KernelInformation.KernelParameters);
+    range = params(1,1);
+    sill = params(2,1);
+end
+
+loss = gprMdl.LogLikelihood/length(lats); % Normalized joint log-likelihood
+
+methodName = 'GP Regression, Max Likelihood';
+methodNameShort = 'GPR, ML';
+
+% Wrapper for the matlab gp fit method
+% A small noise value ('Sigma') is assigned for numerical stability
+function GPmodel = fitgp(X, y, kernel, kernel_init)
+GPmodel = fitrgp(X,y,'BasisFunction', 'none', ...
+        'KernelFunction',kernel,'KernelParameters',kernel_init, ...
+        'FitMethod','exact','Optimizer','lbfgs', ...
+        'Sigma',1e-4, 'ConstantSigma', true, 'SigmaLowerBound', 1e-6);
+end
+
+end

--- a/fn_compute_variogram.m
+++ b/fn_compute_variogram.m
@@ -4,6 +4,7 @@ function [sill, range, h, gamma, nPairs, methodName, methodNameShort] = fn_compu
 % initial code from Christophe Loth, 09/12/12
 % heavily modified by Jack Baker 2/1/2019
 % last updated 3/17/2020
+% modified by Lukas Bodenmann 04/13/2022: Incorporate MLL
 %
 % Calculate empirical semivariograms from data, using several fitting
 % techniques
@@ -59,6 +60,10 @@ end
 
 [sill, range, ~, methodName, methodNameShort] = fit_vario(h, gamma, nPairs, options);
 
+% MLL method operates directly with long/lat
+if any(options.fitMethod==7)
+    [sill(end+1), range(end+1), ~, methodName{end+1}, methodNameShort{end+1}] = fit_MLL(lats, longs, values, options);
+
 % Plot the results
 if options.plotFig
     hPlot = 0:0.5:options.maxR; % use a finer distance resolution for plotting semivariograms
@@ -69,7 +74,11 @@ if options.plotFig
     hEmp=plot(h, gamma, '.k', 'linewidth', 2);
     hold on
     for i = 1:length(options.fitMethod)
-        h(i) = plot(hPlot, sill(i) * (1-exp(-3.*hPlot./range(i))),options.linespec{i});
+        if options.funcForm == 1
+            h(i) = plot(hPlot, sill(i) * (1-exp(-3.*hPlot./range(i))),options.linespec{i});
+        elseif options.funcForm == 2
+            h(i) = plot(hPlot, sill(i) * (1-exp(-(hPlot.^0.55)./range(i))),options.linespec{i});
+        end
         legendText{i+1} = methodName{i};
     end
     legend(legendText, 'location', 'southeast')

--- a/pos2distv.m
+++ b/pos2distv.m
@@ -1,0 +1,71 @@
+function dist = pos2distv(XN, XM)
+
+% Vectorized version by Lukas Bodenmann, 04/13/2022
+% Supports currently only method 1: plane approximation,
+% which was also used in the original study.
+% XN and XM are matrices with latitudes in the first column and longitudes in the
+% second column.
+% The result is a matrix with distances in km between each (lon,lat) pair
+% in XN and each (lon,lat) pair in XM.
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+% calculate distance between two points on earth's surface
+% given by their latitude-longitude pair.
+% Input lag1,lon1,lag2,lon2 are in degrees, without 'NSWE' indicators.
+% Input method is 1 or 2. Default is 1.
+% Method 1 uses plane approximation,
+% only for points within several tens of kilometers (angles in rads):
+% d =
+% sqrt(R_equator^2*(lag1-lag2)^2 + R_polar^2*(lon1-lon2)^2*cos((lag1+lag2)/2)^2)
+% Method 2 calculates sphereic geodesic distance for points farther apart,
+% but ignores flattening of the earth:
+% d =
+% R_aver * acos(cos(lag1)cos(lag2)cos(lon1-lon2)+sin(lag1)sin(lag2))
+% Output dist is in km.
+% Returns -99999 if input argument(s) is/are incorrect.
+%
+% Flora Sun, University of Toronto, Jun 12, 2004.
+%
+% Downloaded from Matlab File Exchange, 
+% https://www.mathworks.com/matlabcentral/fileexchange/5256-pos2dist
+%
+% Copyright 2004, Flora Sun
+%
+% Redistribution and use in source and binary forms, with or without 
+% modification, are permitted provided that the following conditions are met:
+%
+% 1. Redistributions of source code must retain the above copyright notice,
+% this list of conditions and the following disclaimer.
+% 
+% 2. Redistributions in binary form must reproduce the above copyright 
+% notice, this list of conditions and the following disclaimer in the 
+% documentation and/or other materials provided with the distribution.
+% 
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+% "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED 
+% TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR 
+% PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+% CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, 
+% EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, 
+% PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; 
+% OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+% WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR 
+% OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF 
+% ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+%
+
+lats1 = XN(:,1);
+longs1 = XN(:,2);
+longs1(longs1<0) = longs1(longs1<0) + 360;
+XM = XM';
+lats2 = XM(1,:);
+longs2 = XM(2,:);
+longs2(longs2<0) = longs2(longs2<0) + 360;
+
+km_per_deg_la = 111.3237;
+km_per_deg_lo = 111.1350;
+km_la = km_per_deg_la * (lats1 - lats2);
+dif_lo = abs(longs1 - longs2);
+dif_lo(dif_lo > 180) = dif_lo(dif_lo > 180) - 180;
+km_lo = km_per_deg_lo * dif_lo .* cos((lats1+lats2).*pi./360);
+dist = sqrt(km_la.^2 + km_lo.^2);


### PR DESCRIPTION
This fitting option finds the lengthscale (range) of spatial correlation that maximizes the joint likelihood of the within-event-residuals. The latter is based on a multivariate normal distribution.